### PR TITLE
Path url_for to work on on Rails 4.2

### DIFF
--- a/lib/subdomain_fu/url_rewriter.rb
+++ b/lib/subdomain_fu/url_rewriter.rb
@@ -3,7 +3,19 @@ require 'action_dispatch/routing/route_set'
 module ActionDispatch
   module Routing
     class RouteSet #:nodoc:
-      def url_for_with_subdomains(options, path_segments=nil)
+      # Known Issue: Monkey-patching `url_for` is error-prone.
+      # For example, in rails 4.2, the method signature changed from
+      #
+      #     def url_for(options)
+      #
+      # to
+      #
+      #     def url_for(options, route_name = nil, url_strategy = UNKNOWN)
+      #
+      # Is there an alternative design using composition or class
+      # inheritance?
+
+      def url_for_with_subdomains(options, *args)
         if SubdomainFu.needs_rewrite?(options[:subdomain], (options[:host] || @request.host_with_port)) || options[:only_path] == false
           options[:only_path] = false if SubdomainFu.override_only_path?
           options[:host] = SubdomainFu.rewrite_host_for_subdomains(options.delete(:subdomain), options[:host] || @request.host_with_port)
@@ -11,7 +23,7 @@ module ActionDispatch
         else
           options.delete(:subdomain)
         end
-        url_for_without_subdomains(options)
+        url_for_without_subdomains(options, *args)
       end
       alias_method_chain :url_for, :subdomains
     end


### PR DESCRIPTION
This PR keeps compatibility with Rails 3.2 and 4.1
- Introduced missing arguments that Rails 4.2 requires
